### PR TITLE
tests: add basic test

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -x
+script_dir=$(dirname -- "$(readlink -f -- "$0")")
+cargo_toml_path="$script_dir/../Cargo.toml"
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+cargo build --manifest-path="$cargo_toml_path"

--- a/tests/test_cln_ntfy.py
+++ b/tests/test_cln_ntfy.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+
+from pyln.testing.fixtures import *  # noqa: F403
+from util import get_plugin  # noqa: F401
+
+
+def test_basic(node_factory, get_plugin):  # noqa: F811
+    node = node_factory.get_node(
+        options={
+            "plugin": get_plugin,
+            "ntfy-url": "https://ntfy.sh",
+            "ntfy-topic": "cln-alerts",
+            "ntfy-username": "username",
+            "ntfy-password": "password",
+        }
+    )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import random
+import string
+from pathlib import Path
+
+import pytest
+
+RUST_PROFILE = os.environ.get("RUST_PROFILE", "debug")
+COMPILED_PATH = Path.cwd() / "target" / RUST_PROFILE / "cln-ntfy"
+DOWNLOAD_PATH = Path.cwd() / "tests" / "cln-ntfy"
+
+
+@pytest.fixture
+def get_plugin(directory):
+    if COMPILED_PATH.is_file():
+        return COMPILED_PATH
+    elif DOWNLOAD_PATH.is_file():
+        return DOWNLOAD_PATH
+    else:
+        raise ValueError("No files were found.")
+
+
+def generate_random_label():
+    label_length = 8
+    random_label = "".join(
+        random.choice(string.ascii_letters) for _ in range(label_length)
+    )
+    return random_label
+
+
+def generate_random_number():
+    return random.randint(1, 20_000_000_000_000_00_000)
+
+
+def pay_with_thread(rpc, bolt11):
+    LOGGER = logging.getLogger(__name__)
+    try:
+        rpc.dev_pay(bolt11, dev_use_shadow=False)
+    except Exception as e:
+        LOGGER.debug(f"Error paying payment hash:{e}")
+        pass


### PR DESCRIPTION
Hi, since the plugins repo will require plugins to have tests in the future, here is a very basic test.
`setup.sh` will build the binary during CI. `tests/test_cln_ntfy.py` contains the test and currently only checks if the plugins starts with the node and if the plugin options exist.

It would be nice to actually test a notification!

You can run tests like this:

Install dependencies:
```bash
pip3 install pyln-client pyln-testing
```

Build the plugin
```
cargo build
```

run tests :
```
pytest tests/test_cln_ntfy.py
# if you use a different profile than debug for compiling set the RUST_PROFILE like this:
RUST_PROFILE=release pytest tests/test_cln_ntfy.py
```
